### PR TITLE
Fix for cross world boundaries being incompatible for distance computation

### DIFF
--- a/src/com/github/Kraken3/AFKPGC/ActivityBounds.java
+++ b/src/com/github/Kraken3/AFKPGC/ActivityBounds.java
@@ -29,8 +29,12 @@ public class ActivityBounds {
 	private void reset(List<Location> points) {
 		xLow = yLow = zLow = Double.MAX_VALUE;
 		xHigh = yHigh = zHigh = Double.MIN_VALUE;
+		String world = points.get(points.size() - 1).getWorld().getName();
 		
 		for (Location l : points) {
+			if (!world.equals(l.getWorld().getName()) ) {
+				continue;
+			}
 			double x = l.getX();
 			double y = l.getY();
 			double z = l.getZ();

--- a/src/com/github/Kraken3/AFKPGC/LastActivity.java
+++ b/src/com/github/Kraken3/AFKPGC/LastActivity.java
@@ -59,10 +59,12 @@ public class LastActivity{
 	public int calculateMovementRadius() {
 		Location current = loggedLocations.getLast();
 		int distance = 0;
-		for(int i=0; i < loggedLocations.size()-1; i++) {
-			int possibleNewDistance = (int) loggedLocations.get(i).distance(current);
-			if (possibleNewDistance > distance) {
-				distance = possibleNewDistance;
+		for(Location l : loggedLocations ) {
+			if (current.getWorld().getName().equals(l.getWorld().getName())) {
+				int possibleNewDistance = (int) l.distance(current);
+				if (possibleNewDistance > distance) {
+					distance = possibleNewDistance;
+				}
 			}
 		}
 		return distance;


### PR DESCRIPTION
@ttk2 this should fix that error you're getting.

@Maxopoly just look it over, make sure I'm not missing anything.

This solves the following error:

If people move between worlds (End, World, Nether) their location distances cannot be computed, and as such an exception is being generated. This appears to interfere with normal operation of BotDetector. This should solve that in both the distance and bounds computation, with the "top" (most recently sampled) world being the only world used for distance and bound computation.