### PR TITLE
Nightly fixes 1

### DIFF
--- a/src/com/github/Kraken3/AFKPGC/BotDetector.java
+++ b/src/com/github/Kraken3/AFKPGC/BotDetector.java
@@ -126,7 +126,7 @@ public class BotDetector implements Runnable {
 				if (lastActivities.containsKey(playerUUID) && p != null) {
 					LastActivity la = entry.getValue();
 					la.loggedLocations.add(p.getLocation());
-					if (la.loggedLocations.size() > maxLocations) {
+					while (la.loggedLocations.size() > maxLocations) {
 						la.loggedLocations.removeFirst();
 					} 
 					
@@ -148,7 +148,7 @@ public class BotDetector implements Runnable {
 				if (lastActivities.containsKey(playerUUID) && p != null) {
 					LastActivity la = entry.getValue();
 					if (!reprieve.containsKey(playerUUID) && !AFKPGC.immuneAccounts.contains(playerUUID)) {
-						if (la.loggedLocations.size() == maxLocations) {
+						if (la.loggedLocations.size() >= maxLocations) {
 							int itWasntMeISwear = la.calculateMovementRadius();
 							if (itWasntMeISwear < smallestMovedDistance) {
 								Player dirtyLiar = Bukkit.getPlayer(playerUUID);

--- a/src/com/github/Kraken3/AFKPGC/LagScanner.java
+++ b/src/com/github/Kraken3/AFKPGC/LagScanner.java
@@ -114,10 +114,7 @@ public class LagScanner {
 				long chunkId = ((long) x << 32L) + (long) z;
 				LagScanner.Result result = lcache.get(chunkId);
 				if (result != null && result.lagContrib >= unloadThreshold) {
-					Chunk nC = chunkWorld.getChunkAt(x, z);
-					if (nC != null) {
-						nC.unload(true, true);
-					}
+					chunkWorld.unloadChunkRequest(x, z, true);
 				}
 			}
 		}
@@ -197,15 +194,13 @@ public class LagScanner {
 			// record the result.
 			result = new LagScanner.Result(world, chunkId, chunk.getX(), chunk.getZ(), totalCost, now);
 			worldCache.put(chunkId, result);
-			AFKPGC.debug("The chunk ", chunk.getX(), ", ", chunk.getZ(), " measures ", result.lagContrib, " lag sources, details: ", sb);
+			AFKPGC.debug("The chunk ", chunk.getX(), ", ", chunk.getZ(), " measures ", result.lagContrib, " lag sources", result.lagContrib < normalChunkValue ? "(ignored)" : "",", details: ", sb);
 		}
 		else {
-			AFKPGC.debug("The chunk ", chunk.getX(), ", ", chunk.getZ(), " was loaded from the cache with a measure of ", result.lagContrib, " lag sources");
+			AFKPGC.debug("The chunk ", chunk.getX(), ", ", chunk.getZ(), " was loaded from the cache with a measure of ", result.lagContrib, " lag sources", result.lagContrib < normalChunkValue ? " (ignored)": "");
 		}
 		if (result.lagContrib < normalChunkValue) {
-			AFKPGC.debug("The chunk ", chunk.getX(), ", ", chunk.getZ(), " was ignored for the lag "
-					+ "contribution, because it was below the normal chunk value");
-			return new LagScanner.Result(null, 0, 0, 0, 0L, 0L);  
+			return new LagScanner.Result(null, 0, 0, 0, 0, 0);
 			//this is only used to read the lag contribution and does its job to deliver that
 		}
 		return result;


### PR DESCRIPTION
The "ignored" line is a big pain to filter out, removed it.

Noticed that people were sitting in the "insufficient location information" box for WAY longer then should (like 20+ scan cycles) indicating that somehow or someway we had "too many" locations for them. Fixed the code to address this edge case (that should have been impossible but apparently isn't).

Last fix for this branch/version. Next pull will be a refactor.