### PR TITLE
Scan Refactor to not use location tracking features but scan directly

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,10 +9,10 @@ debug: true
 #   Use 0 as an amount of seconds when you don't want to kick people.
 
 kick_thresholds:
-  - When 81 to 500 players online kick after 60 seconds
-  - When 51 to 80  players online kick after 120 seconds
-  - When 2  to 50  players online kick after 240 seconds
-  - When 1  to 1  players online kick after 3600 seconds  
+  - When 101 to 500  players online kick after 150 seconds
+  - When 76 to 100  players online kick after 300 seconds
+  - When 51 to 75  players online kick after 900 seconds
+  - When 1  to 50  players online kick after 7200 seconds
   
 bot_detector:
   # Once the TPS get below acceptable_TPS, the BotDetector starts culling potential lag causer.
@@ -26,15 +26,17 @@ bot_detector:
   # Completely disables banning for testing and debugging purposes
   observation_mode: false
   # Length of long ban
-  ban_length: 21600000
+  ban_length: 5400000
   # Max locations per player to store while measuring movement patterns
-  max_locations: 8
+  max_locations: 10
+  # Max suspects to consider per Detector round
+  max_suspects: 10
   # Maximum scan rounds to "ignore" a player who was previously cleared as a lag source
-  max_reprieve: 10
+  max_reprieve: 20
   # Number of BotDetector rounds at good TPS before releasing lag offenders
-  release_rounds: 20
+  release_rounds: 40
   # Scan radius in chunks around location, to check for lag causes
-  scan_radius: 4
+  scan_radius: 3
   # Amount of players checked per run
   players_checked_per_run: 5
   # Max players kicked per run
@@ -58,11 +60,11 @@ lag_scanner:
   # Length of time to cache individual chunk results (in milliseconds)
   cache_timeout: 1800000
   # Summation threshold of entity and tile costs for lag flag
-  lag_threshold: 400
+  lag_threshold: 750
   # Multiplier of the lag threshold that needs to be exceeded to be banned right away
-  extreme_lag_threshold_multiplier: 2.5
+  extreme_lag_threshold_multiplier: 4.5
   # Reduction Factor (threshold * unload should be < threshold) that must be exceeded to attempt to force unload chunks
-  unload_threshold_factor: .25
+  unload_threshold_factor: 0.17
   # Flag indicating if chunk force unloading on kick should be active
   perform_unload: true
   # Whether the lag scanner should keep scanning if it already determined someone is causing lag
@@ -73,52 +75,55 @@ lag_scanner:
   normal_chunk_value: 100
   # Per tickable block cost 
   tick_block:
-    BANNER: 1
-    BEACON: 5
+    PISTON_MOVING_PIECE: 16
+    PISTON_EXTENSION: 8
+    BANNER: 0
+    BEACON: 3
     BREWING_STAND: 1
-    MOB_SPAWNER: 3
-    DROPPER: 3
+    MOB_SPAWNER: 5
+    DROPPER: 5
     JUKEBOX: 1
     NOTE_BLOCK: 1
-    SIGN: 1
+    SIGN: 0
     HOPPER: 8
-    DISPENSER: 3
-    FURNACE: 3
+    DISPENSER: 5
+    FURNACE: 2
     BURNING_FURNACE: 4
-    CHEST: 1
-    ACTIVATOR_RAIL: 1
+    CHEST: 0
+    TRAPPED_CHEST: 0
+    ENDER_CHEST: 0
+    ACTIVATOR_RAIL: 2
     DETECTOR_RAIL: 1
     DAYLIGHT_DETECTOR: 1
     DAYLIGHT_DETECTOR_INVERTED: 1
     DIODE: 1
     DIODE_BLOCK_OFF: 1
-    DIODE_BLOCK_ON: 1
-    PISTON_BASE: 2
-    PISTON_STICKY_BASE: 2
-    PISTON_MOVING_PIECE: 8
-    PISTON_EXTENSION: 4
-    POWERED_RAIL: 1
+    DIODE_BLOCK_ON: 2
+    PISTON_BASE: 8
+    PISTON_STICKY_BASE: 8
+    POWERED_RAIL: 2
     REDSTONE_COMPARATOR: 1
     REDSTONE_COMPARATOR_OFF: 1
-    REDSTONE_COMPARATOR_ON: 1
+    REDSTONE_COMPARATOR_ON: 2
     REDSTONE_LAMP_OFF: 1
-    REDSTONE_LAMP_ON: 1
+    REDSTONE_LAMP_ON: 2
     REDSTONE_TORCH_OFF: 1
-    REDSTONE_TORCH_ON: 1
-    WALL_BANNER: 1
-    WALL_SIGN: 1
-    SIGN_POST: 1
+    REDSTONE_TORCH_ON: 2
+    WALL_BANNER: 0
+    WALL_SIGN: 0
+    SIGN_POST: 0
+    ITEM_FRAME: 0
   # Per tickable entity cost
   tick_entity:
     BAT: 1
-    FALLING_BLOCK: 4
-    DROPPED_ITEM: 1
     ARMOR_STAND: 1
-    BOAT: 2
+    BOAT: 4
+    FALLING_BLOCK: 16
+    DROPPED_ITEM: 1
     CAVE_SPIDER: 1
     CHICKEN: 1
     COW: 1
-    CREEPER: 1
+    CREEPER: 2
     ENDERMAN: 2
     ENDERMITE: 1
     GHAST: 2
@@ -126,29 +131,29 @@ lag_scanner:
     HORSE: 1
     IRON_GOLEM: 2
     MAGMA_CUBE: 2
-    MINECART: 1
+    MINECART: 3
     MINECART_CHEST: 1
-    MINECART_FURNACE: 2
-    MINECART_HOPPER: 5
-    MINECART_TNT: 3
+    MINECART_FURNACE: 3
+    MINECART_HOPPER: 8
+    MINECART_TNT: 6
     MUSHROOM_COW: 1
-    OCELOT: 1
-    PAINTING: 1
+    OCELOT: 2
+    PAINTING: 0
     PIG: 1
     PIG_ZOMBIE: 1
-    PRIMED_TNT: 3
+    PRIMED_TNT: 5
     RABBIT: 1
     SHEEP: 1
     SILVERFISH: 2
     SKELETON: 2
-    SLIME: 2
+    SLIME: 3
     SNOWMAN: 2
     SPIDER: 1
     SQUID: 1
     VILLAGER: 1
-    WITCH: 2
-    WITHER: 3
-    WOLF: 1
+    WITCH: 3
+    WITHER: 5
+    WOLF: 2
     ZOMBIE: 1
 
 # warnings field reads the first number, the rest is text to be sent to a player

--- a/config.yml
+++ b/config.yml
@@ -22,7 +22,9 @@ bot_detector:
   # kicking_frequency is how often the bot detector runs in ticks
   kicking_frequency: 1800
   # Whether players get banned for a long time/ until the tick is high again
-  long_bans: false
+  enable_bans: false
+  # Whether Players get warnings before bans if set to true
+  enable_warnings: true
   # Completely disables banning for testing and debugging purposes
   observation_mode: false
   # Length of long ban
@@ -31,20 +33,18 @@ bot_detector:
   max_locations: 8
   # Max suspects to consider per Detector round
   max_suspects: 10
-  # Baseline movement (in MC blocks) to be considered for bot detection
-  min_baseline: 256
   # Maximum scan rounds to "ignore" a player who was previously cleared as a lag source
   max_reprieve: 10
   # Number of BotDetector rounds at good TPS before releasing lag offenders
   release_rounds: 20
   # Scan radius in chunks around location, to check for lag causes
   scan_radius: 4
-  # Kick players very close to high-profile lag sources
-  kick_nearby: true
-  # Radius to consider if kicking nearby players
-  kick_nearby_radius: 16
   # Amount of players checked per run
-  players_checked_per_run: 1
+  players_checked_per_run: 5
+  # Max players kicked per run
+  max_kicked_per_run: 4
+  # percentage of online players that need to have been scanned before kicking/warning begins
+  action_threshold: 0.8
   # Distance a player needs to move away from a lagsource to not get kicked if he is caught by the system again
   safe_distance: 128
   # Configure the threshold and individual contribution of bound types

--- a/config.yml
+++ b/config.yml
@@ -17,8 +17,6 @@ kick_thresholds:
 bot_detector:
   # Once the TPS get below acceptable_TPS, the BotDetector starts culling potential lag causer.
   acceptable_TPS: 17.5
-  #Once the tps goes below this value, locations start to get logged
-  starting_TPS: 18
   # kicking_frequency is how often the bot detector runs in ticks
   kicking_frequency: 1800
   # Whether players get banned for a long time/ until the tick is high again
@@ -31,8 +29,6 @@ bot_detector:
   ban_length: 21600000
   # Max locations per player to store while measuring movement patterns
   max_locations: 8
-  # Max suspects to consider per Detector round
-  max_suspects: 10
   # Maximum scan rounds to "ignore" a player who was previously cleared as a lag source
   max_reprieve: 10
   # Number of BotDetector rounds at good TPS before releasing lag offenders

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.github.Kraken3</groupId>
   <artifactId>AFKPGC</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.2-${build.version}</version>
+  <version>1.3.3-${build.version}</version>
   <name>AFKPGC</name>
   <url>https://github.com/civcraft/AFKPGC</url>
   

--- a/src/com/github/Kraken3/AFKPGC/BotDetector.java
+++ b/src/com/github/Kraken3/AFKPGC/BotDetector.java
@@ -145,7 +145,8 @@ public class BotDetector implements Runnable {
 					LastActivity la = entry.getValue();
 
 					// Find fresh blood.
-					if (!reprieve.containsKey(playerUUID) && !topSuspectsLookup.containsKey(playerUUID)) {
+					if (!AFKPGC.immuneAccounts.contains(playerUUID) && !reprieve.containsKey(playerUUID) &&
+							!topSuspectsLookup.containsKey(playerUUID)) {
 						// do scan.
 						Location point = p.getLocation();
 						AFKPGC.debug("Player ", playerUUID, " (", p.getName(), ") at ", point,

--- a/src/com/github/Kraken3/AFKPGC/BotDetector.java
+++ b/src/com/github/Kraken3/AFKPGC/BotDetector.java
@@ -11,9 +11,11 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.NavigableSet;
 import java.util.UUID;
 import java.util.TreeMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -30,35 +32,41 @@ import org.bukkit.entity.Player;
  * 
  */
 public class BotDetector implements Runnable {
-	public static boolean longBans;
 	public static float currentTPS = 20;
 	public static float acceptableTPS;
-	public static float startingTPS;
 	public static double relaxationFactor;
 	public static int maxLocations;
-	public static int maxSuspects;
 	public static int maxReprieve;
-	public static int minBaselineMovement;
 	public static long longBan;
 	public static int scanRadius;
 	public static BoundResultsConfiguration boundsConfig;
 	public static long frequency; // how often this runs in ticks
 	public static File banfile;
-	public static boolean kickNearby;
-	public static int kickNearbyRadius;
 	public static boolean observationMode;
 	public static int releaseRounds;
 	public static int amountOfChecksPerRun;
+	public static int maxKicksPerRun;//TODO
 	public static int safeDistance;
+	/** Number of people scanned between suspects and reprieve list before kicks begin, as a function
+	  * of online players. */
+	public static float actionThreshold;
 
-	TreeMap<Integer, Suspect> topSuspects;
+	/** Boolean indicator if bans are active. Warnings can be active without bans, for instance. */
+	public static boolean enableBans;
+
+	/** Boolean indicator if warnings are active. Bans can be active without warnings, for instance. */
+	public static boolean enableWarnings;
+
+	HashMap<UUID, Suspect> topSuspectsLookup; // UUID lookup.
+	TreeMap<Long, Set<Suspect>> topSuspects;
 	HashMap<UUID, Integer> reprieve; // temp. cleared suspects
 
 	int goodRounds = 0;
 	
-	public static LinkedList<Suspect> warnedPlayers = new LinkedList<Suspect>();
+	public static HashSet<Suspect> warnedPlayers = new HashSet<Suspect>();
 	/* this is needed as a separated list, so we know the difference between players
 	 * who were banned by AFKPGC and players who were banned for other reasons */
+	//TODO: convert to UUID
 	public static LinkedList<String> bannedPlayers = new LinkedList<String>();
 
 	// ban after names not ips
@@ -92,8 +100,12 @@ public class BotDetector implements Runnable {
 
 	public synchronized void doDetector() {
 		if (topSuspects == null) {
-			topSuspects = new TreeMap<Integer, Suspect>();
+			topSuspects = new TreeMap<Long, Set<Suspect>>();
 		}
+		if (topSuspectsLookup == null) {
+			topSuspectsLookup = new HashMap<UUID, Suspect>();
+		}
+
 		if (reprieve == null) {
 			reprieve = new HashMap<UUID, Integer>();
 		} else {
@@ -119,161 +131,197 @@ public class BotDetector implements Runnable {
 		currentTPS = TpsReader.getTPS();
 		AFKPGC.debug("Bot Detector Running, TPS is: ", currentTPS);
 		Map<UUID, LastActivity> lastActivities = LastActivity.lastActivities;
-		if (currentTPS < startingTPS) {
-			for (Map.Entry<UUID, LastActivity> entry : lastActivities.entrySet()) {
-				UUID playerUUID = entry.getKey();
-				Player p = Bukkit.getPlayer(playerUUID);
-				if (lastActivities.containsKey(playerUUID) && p != null) {
-					LastActivity la = entry.getValue();
-					la.loggedLocations.add(p.getLocation());
-					while (la.loggedLocations.size() > maxLocations) {
-						la.loggedLocations.removeFirst();
-					} 
-					
-				}
-			}
-		}
 		if (currentTPS < acceptableTPS) {
 			goodRounds = 0;
-			topSuspects.clear();
-			int smallestMovedDistance = minBaselineMovement;
-			// find new top suspects
+			int scanCount = 0;
+			HashSet<UUID> justScanned = new HashSet<UUID>();
 			for (Map.Entry<UUID, LastActivity> entry : lastActivities.entrySet()) {
 				UUID playerUUID = entry.getKey();
 				Player p = Bukkit.getPlayer(playerUUID);
-				/* according to the author of AFKGPC, there might be
-				 * inconsistencies in this list, so this additional
-				 * check is needed */
-				// TODO: See if inconsistencies might be thread-safeness related.
-				if (lastActivities.containsKey(playerUUID) && p != null) {
+				if (p == null) {
+					AFKPGC.debug("Player ", playerUUID, " is likely offline, skipping for now");
+					continue;
+				} else if (lastActivities.containsKey(playerUUID)) { // threadsafe consistency check.
 					LastActivity la = entry.getValue();
-					if (!reprieve.containsKey(playerUUID) && !AFKPGC.immuneAccounts.contains(playerUUID)) {
-						if (la.loggedLocations.size() >= maxLocations) {
-							int itWasntMeISwear = la.calculateMovementRadius();
-							if (itWasntMeISwear < smallestMovedDistance) {
-								Player dirtyLiar = Bukkit.getPlayer(playerUUID);
-								topSuspects.put(itWasntMeISwear, new Suspect(
-									playerUUID, dirtyLiar.getName(), dirtyLiar.getLocation(),
-									la.evaluateBounds(relaxationFactor) ) );
-								if (topSuspects.size() > maxSuspects) {
-									Suspect cleared = topSuspects.pollLastEntry().getValue(); // gets rid of largest distance
-									AFKPGC.debug("Player ", cleared.getUUID(), " released as suspect, better suspects found");
-								}
+
+					// Find fresh blood.
+					if (!reprieve.containsKey(playerUUID) && !topSuspectsLookup.containsKey(playerUUID)) {
+						// do scan.
+						Location point = p.getLocation();
+						AFKPGC.debug("Player ", playerUUID, " (", p.getName(), ") at ", point,
+								" next up for Scanner");
+						justScanned.add(playerUUID);
+
+						LagScanner ls = new LagScanner(point, scanRadius, null, false);
+						ls.run(); // TODO: move this and ban results to thread.
+						if (ls.isLagSource()) {
+							Suspect crim = new Suspect(playerUUID, p.getName(), point, ls.getLagCompute());
+							Set<Suspect> cellmates = topSuspects.get(ls.getLagCompute());
+							if (cellmates == null) {
+								cellmates = new HashSet<Suspect>();
+								topSuspects.put(ls.getLagCompute(), cellmates);
 							}
+							cellmates.add(crim);
+							topSuspectsLookup.put(playerUUID, crim);
+							AFKPGC.debug("Player ", playerUUID, " (", crim.getName(), ") at ", point,
+									" exceeded baseline lag threshold [", ls.getLagCompute(), "], added to watch list");
 						} else {
-							AFKPGC.debug("Skipping ", playerUUID, " due to insufficient location data");
+							reprieve.put(playerUUID, maxReprieve);
+							AFKPGC.debug("Player ", playerUUID, " (", p.getName(), ") at ", point, 
+									" below baseline lag threshold [", ls.getLagCompute(), "], given reprieve");
 						}
+						scanCount ++;
 					} else {
-						AFKPGC.debug("Skipping ", playerUUID, " due to reprieve or immunity");
+						continue;
 					}
+					
+					if (scanCount >= amountOfChecksPerRun) {
+						break;
+					}
+					// Scan N people.
+
+					// Evaluate if we've scanned enough people to issue warnings
+
+					// Issue M warnings
+					
+					// if we're issuing a second warning, scan again
+
+					// If scan is still bad, kick / ban (unless in obs. mode)
+
+					// add to banlist
+
 				} else {
-					AFKPGC.debug("Player ", playerUUID, " likely offline.");
+					AFKPGC.debug("Player ", playerUUID, " (", p.getName(), ") was removed from tracking while Detector was running, skipping for now.");
 				}
 			}
-			// Now find first top suspect to pass the truebot tests.
-			int peopleToCheck = amountOfChecksPerRun;
-			if (peopleToCheck > topSuspects.size()) {
-				peopleToCheck = topSuspects.size();
-			}
-			if (peopleToCheck > 0) {
-				for (Map.Entry<Integer, Suspect> entry : topSuspects.entrySet()) {
-					Suspect curSuspect = entry.getValue();
-					// Test Bounds for truebot(tm) detection.
-					BoundResults bounds = curSuspect.getResults();
-					if (bounds != null) {
-						double truebot = 0.0;
-						truebot += (bounds.getContained() ? boundsConfig.getContained() : 0.0);
-						truebot += (bounds.getContainedExcludeY() ? boundsConfig.getContainedExcludeY() : 0.0);
-						truebot += (bounds.getVolumeSimilar() ? boundsConfig.getVolumeSimilar() : 0.0);
-						truebot += (bounds.getSurfaceSimilar() ? boundsConfig.getSurfaceSimilar() : 0.0);
-						truebot += (bounds.getNearlyContained() ? boundsConfig.getNearlyContained() : 0.0);
-						truebot += (bounds.getNearlyContainedExcludeY() ? 
-								boundsConfig.getNearlyContainedExcludeY() : 0.0);
 
-						if (truebot >= boundsConfig.getThreshold()) {
-							// Its movement looks botlike.
-							AFKPGC.debug("Player ", curSuspect.getUUID(), " (", curSuspect.getName(), 
-									") looks like a bot (bounds test ", truebot, "): ", bounds);
+			if (topSuspectsLookup.size() + reprieve.size() >= (int) Math.floor(lastActivities.size() * actionThreshold)) {
+				AFKPGC.debug("Scanned ", topSuspectsLookup.size() + reprieve.size(), " players, ", 
+						lastActivities.size(), " online/tracking, which exceeds ", 
+						(int) Math.ceil(lastActivities.size() * actionThreshold), " so warning and kicking.");
+				HashSet<Suspect> updates = new HashSet<Suspect>();
+				int curKicks = 0;
+				// we're ready to warn or kick the top "baddies".
+				NavigableSet<Long> scanSlots = topSuspects.descendingKeySet();
+				for (Long cell : scanSlots) {
+					Set<Suspect> cellmates = topSuspects.get(cell);
+					for (Suspect suspect : cellmates) {
+						// rescan and update/remove based on results.
+						UUID suspectUUID = suspect.getUUID();
 
-							// Now test surrounding area.
-							Location point = curSuspect.getLocation();
+						Player p = Bukkit.getPlayer(suspectUUID);
 
-							LagScanner ls = new LagScanner(point, scanRadius, null);
-							ls.run(); // TODO: move this and ban results to thread.
-							if (ls.isLagSource()) {
-								if (longBans && ls.isExtremeLagSource()) {
-									if (!observationMode) {
-										giveOutLongBan(curSuspect);
+						if (p != null && lastActivities.containsKey(suspectUUID)) {
+							Long oldScore = suspect.getResults();
+
+							Location point = p.getLocation();
+
+							// TODO: check justScanned before scanning.
+							boolean recent = justScanned.contains(suspectUUID);
+							boolean source = true;
+
+							if (!recent) {
+								AFKPGC.debug("Player ", suspectUUID, " (", suspect.getName(), ") at ",
+										point, " is a top suspect, rescanning");
+								LagScanner ls = new LagScanner(point, scanRadius, null, true);
+								ls.run(); // TODO: move this and ban results to thread.
+								suspect.update(point, ls.getLagCompute());
+								source = ls.isLagSource();
+							} else {
+								AFKPGC.debug("Player ", suspectUUID, " (", suspect.getName(), ") at ",
+										point, " is a top suspect!");
+							}
+							if (source) {
+								curKicks ++;
+								if (oldScore != suspect.getResults()) {
+									cellmates.remove(suspect);
+									if (cellmates.size() < 1) {
+										scanSlots.remove(cell);
 									}
-									AFKPGC.debug("Player ", curSuspect.getUUID(), " (", curSuspect.getName(), 
-											") is an extreme lag source with a lag compute of ", ls.getLagCompute());
-								} else {
-									if (!observationMode) {
-										if (!warnedPlayers.contains(curSuspect)) {
-											Player p = Bukkit.getPlayer(curSuspect.getUUID());
-											warnPlayer(p);
-											warnedPlayers.add(curSuspect);
-										}
-										else {
-											//The person has been warned already, check whether he is in the same region.
-											Player p = Bukkit.getPlayer(curSuspect.getUUID());
-											if (p != null) {
-												boolean found = false;
-												for(Suspect warned:warnedPlayers) {
-													if (curSuspect.equals(warned) && curSuspect.getLocation().getWorld().getName().equals(warned.getLocation().getWorld().getName()) && 
-															curSuspect.getLocation().distance(warned.getLocation()) < safeDistance) {
-														AFKPGC.debug(p.getUniqueId()," (",p.getName(),") was warned but didn't listen, so a ban was applied");
-														giveOutLongBan(p);
-														found = true;
-														break;
-													}
-													
-												}
-												if (!found) {
-													warnPlayer(p);
-													warnedPlayers.add(curSuspect);
-													AFKPGC.debug(p.getUniqueId()," (",p.getName(),") was found causing lag at a different location, at ",
-															p.getLocation()," and warned again");
-												}
-												
+									updates.add(suspect);
+								}
+								if (warnedPlayers.contains(suspect)) {
+									// kick, add to ban list.
+									if (enableBans && !observationMode) {
+										giveOutBan(suspect);
+										// Once banned, remove from top list, update, and such.
+										warnedPlayers.remove(suspect);
+										if (updates.contains(suspect)) {
+											updates.remove(suspect); // cancel update
+										} else {
+											cellmates.remove(suspect);
+											if (cellmates.size() < 1) {
+												scanSlots.remove(cell);
 											}
 										}
-									} else {
-										AFKPGC.debug("Player ", curSuspect.getUUID(), " (", curSuspect.getName(),
-												") exceeded warning threshold with ", ls.getLagCompute());
+										topSuspectsLookup.remove(suspectUUID);
+									} else{
+										AFKPGC.debug("Player ", suspectUUID, " (", suspect.getName(), ") at ", 
+												suspect.getLocation(), " was warned but still exceeds baseline lag threshold [", 
+												oldScore, "->", suspect.getResults(), "], kickban skipped due to config");
 									}
-									
-									peopleToCheck--;
-									if (peopleToCheck <= 0) {
-										break;
+								} else {
+									// warn.
+									if (enableWarnings && !observationMode) {
+										warnPlayer(p);
+										warnedPlayers.add(suspect);
+									} else {
+										AFKPGC.debug("Player ", suspectUUID, " (", suspect.getName(), ") at ",
+												suspect.getLocation(), " exceeds baseline lag threshold [", 
+												oldScore, "->", suspect.getResults(), "], warning skipped due to config");
 									}
 								}
-								continue; // don't issue reprieve
-							} else {
-								AFKPGC.debug("Player ", curSuspect.getUUID(), " (", curSuspect.getName(),
-										") cleared via insufficient lagsources [", ls.getLagCompute(), "]");
+							} else { // "good" now.
+								cellmates.remove(suspect);
+								if (cellmates.size() < 1) {
+									scanSlots.remove(cell);
+								}
+								topSuspectsLookup.remove(suspectUUID);
+								AFKPGC.debug("Player ", suspectUUID, " (", suspect.getName(), ") at ",
+										suspect.getLocation(), " no longer exceeds baseline lag threshold [", 
+										oldScore, "->thresh], removed from watch list");
 							}
 						} else {
-							AFKPGC.debug("Player ", curSuspect.getUUID(), " (", curSuspect.getName(),
-									") unlikely bot, cleared via bounding box [", truebot, "]: ", bounds);
+							AFKPGC.debug("Player ", suspectUUID, " (", suspect.getName(), 
+									") is likely offline, skipping recheck for now");
+						} // TODO remove after N skips?
+
+						if (curKicks >= maxKicksPerRun) {
+							break;
 						}
-						// It passed the truebot(tm) detection -- for now. Give a temporary reprieve.
-						reprieve.put(curSuspect.getUUID(), maxReprieve);
-					} else {
-						// else not enough info yet. Pass.
-						AFKPGC.debug("Player ", curSuspect.getUUID(), " suspected due to movement ",
-								" but not enough bounds data, skip this round.");
+					}
+					if (curKicks >= maxKicksPerRun) {
+						break;
 					}
 				}
+				// update update
+				for (Suspect update : updates) {
+					Set<Suspect> cellmates = topSuspects.get(update.getResults());
+					if (cellmates == null) {
+						cellmates = new HashSet<Suspect>();
+						topSuspects.put(update.getResults(), cellmates);
+					}
+					cellmates.add(update);
+				}
+				updates.clear();
+				updates = null;
 			} else {
-				AFKPGC.debug("No suspects this round.");
+				AFKPGC.debug("Scanned ", topSuspectsLookup.size() + reprieve.size(), " players, ", 
+						lastActivities.size(), " online/tracking, need to reach ", 
+						(int) Math.ceil(lastActivities.size() * actionThreshold), " before warning and kicking.");
 			}
+			justScanned.clear();
+			justScanned = null;
 		} else { // TPS is high enough
 			goodRounds ++;
 			if (goodRounds > releaseRounds && bannedPlayers.size() != 0) {
 				AFKPGC.debug("TPS has remained improved, removing bans");
 				freeEveryone(); // not everyone, but everyone banned by this plugin
 				warnedPlayers.clear();
+				reprieve.clear();
+				// safe to clear lists, if they show up and wreck TPS we'll find them quickly.
+				topSuspects.clear();
+				topSuspectsLookup.clear();
 			}
 		}
 	}
@@ -299,52 +347,28 @@ public class BotDetector implements Runnable {
 		}
 	}
 
-	public List<Player> getPlayersWithin(Player player, int distance) {
-		List<Player> res = new ArrayList<Player>();
-		int d2 = distance * distance;
-		for (Player p : Bukkit.getServer().getOnlinePlayers()) {
-			if (p.getWorld() == player.getWorld() && p.getLocation().distanceSquared(player.getLocation()) <= d2) {
-				res.add(p);
-			}
-		}
-		return res;
-	}
-
-    private void giveOutLongBan(Suspect s) {
-    	if (!longBans) {
+    private void giveOutBan(Suspect s) {
+    	if (!enableBans) {
     		return;
     	}
     	Date currentDate=new Date();
     	BanEntry leBan = banList.addBan( s.getName(),
-	    		"You are causing lag, so you were banned",
+	    		"You have been banned due to causing lag, in spite of a warning to leave the area",
 				new Date(currentDate.getTime() + longBan), null); // long ban.
     	Player p = Bukkit.getPlayer(s.getUUID());
 	    if (p != null) {
-	    	if (BotDetector.kickNearby) {
-			    List<Player> nearby = getPlayersWithin(p, BotDetector.kickNearbyRadius);
-			    for (Player q : nearby) {
-			    	BanEntry qBan = banList.addBan(q.getName(), leBan.getReason(),
-						    new Date(currentDate.getTime() + longBan), null);
-				    q.kickPlayer(leBan.getReason());
-				    AFKPGC.debug("Player ", q.getUniqueId(), " (", q.getName(), ") long banned for ",
-						    longBan," confirmed nearby lag source.");
-				    bannedPlayers.add(q.getName());
-					addToBanfile(q.getName());
-			    }
-	    	}
 			LagScanner.unloadChunks(p.getLocation(), scanRadius);
 			p.kickPlayer(leBan.getReason());
 		}
 		bannedPlayers.add(s.getName());
 		addToBanfile(s.getName());
-		warnedPlayers.remove(new Suspect(s.getUUID(),s.getName(),null,null));
 		AFKPGC.debug("Player ", s.getUUID(), " (", s.getName(), ") long banned for ",
 				longBan," confirmed lag source.");
 	}
     
-    private void giveOutLongBan(Player p) {
+    private void giveOutBan(Player p) {
     	if (p != null) {
-    		giveOutLongBan(new Suspect(p.getUniqueId(),p.getName(),p.getLocation(),null));
+    		giveOutBan(new Suspect(p.getUniqueId(),p.getName(),p.getLocation(),null));
     	}
     }
 
@@ -372,18 +396,6 @@ public class BotDetector implements Runnable {
 					+ " Please immediately depart the area (leave render distance) or you will be "
 					+ "temporarily banned.");
 			AFKPGC.debug("Player ", p.getUniqueId(), " (", p.getName(), ") was notified of presence in lag source");
-			if (BotDetector.kickNearby) {
-				List<Player> nearby = getPlayersWithin(p, BotDetector.kickNearbyRadius);
-				for (Player q : nearby) {
-					p.sendMessage("[WARNING] You are near a region with a high concentration of lag sources."
-							+ " Please immediately depart the area (leave render distance) or you will be "
-							+ "temporarily banned.");
-					AFKPGC.debug("Player ", q.getUniqueId(), " (", q.getName(),
-							") warned for being nearby lag source.");
-				}
-			}
-			
-			
 		}
 		
 	}

--- a/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
+++ b/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
@@ -108,35 +108,31 @@ public class ConfigurationReader {
 		AFKPGC.debug("Observation mode: ", BotDetector.observationMode);
 		BotDetector.acceptableTPS = (float) bd.getDouble("acceptable_TPS");
 		AFKPGC.debug("Acceptable TPS: ", BotDetector.acceptableTPS);
-		BotDetector.startingTPS = (float) bd.getDouble("starting_TPS");
-		AFKPGC.debug("Starting TPS: ",BotDetector.startingTPS);
 		BotDetector.frequency = bd.getInt("kicking_frequency");
 		AFKPGC.debug("Detector Frequency: ", BotDetector.frequency);
-		BotDetector.longBans = bd.getBoolean("long_bans");
-		AFKPGC.debug("Activate Long Bans: ", BotDetector.longBans);
+		BotDetector.enableBans = bd.getBoolean("enable_bans"); //TODO
+		AFKPGC.debug("Activate Bans: ", BotDetector.enableBans);
+		BotDetector.enableWarnings = bd.getBoolean("enable_warnings"); //TODO
+		AFKPGC.debug("Activate Warnings: ", BotDetector.enableWarnings);
 		BotDetector.maxLocations = bd.getInt("max_locations");
 		AFKPGC.debug("Max Locs to Track: ", BotDetector.maxLocations);
-		BotDetector.maxSuspects = bd.getInt("max_suspects");
-		AFKPGC.debug("Max Suspects: ", BotDetector.maxSuspects);
 		BotDetector.maxReprieve = bd.getInt("max_reprieve");
 		AFKPGC.debug("Max Reprieve Rounds: ", BotDetector.maxReprieve);
 		BotDetector.releaseRounds = bd.getInt("release_rounds");
 		AFKPGC.debug("Rounds Before Release: ", BotDetector.releaseRounds);
-		BotDetector.minBaselineMovement = bd.getInt("min_baseline");
-		AFKPGC.debug("Min Baseline Movement to not be a bot: ", BotDetector.minBaselineMovement);
 		BotDetector.longBan = bd.getLong("ban_length");
-		AFKPGC.debug("Long Ban Length: ", BotDetector.longBan);
+		AFKPGC.debug("Ban Length: ", BotDetector.longBan);
 		BotDetector.scanRadius = bd.getInt("scan_radius");
 		AFKPGC.debug("Impact Scan Radius: ", BotDetector.scanRadius);
-		BotDetector.kickNearby = bd.getBoolean("kick_nearby");
-		AFKPGC.debug("Kick Nearby: ", BotDetector.kickNearby);
-		BotDetector.kickNearbyRadius = bd.getInt("kick_nearby_radius");
-		AFKPGC.debug("Kick Nearby Radius: ", BotDetector.kickNearbyRadius);
 		BotDetector.amountOfChecksPerRun = bd.getInt("players_checked_per_run");
 		AFKPGC.debug("Players checked per run:", BotDetector.amountOfChecksPerRun);
+		BotDetector.maxKicksPerRun = bd.getInt("max_kicked_per_run");
+		AFKPGC.debug("Players checked per run:", BotDetector.amountOfChecksPerRun);
+		BotDetector.actionThreshold = (float) bd.getDouble("action_threshold");
+		AFKPGC.debug("Action Threshold:", BotDetector.actionThreshold);
 		BotDetector.safeDistance = bd.getInt("safe_distance");
-		AFKPGC.debug("Safe distance: ",BotDetector.safeDistance);
-		ConfigurationSection bdbc = bd.getConfigurationSection("bounds");
+		AFKPGC.debug("Safe distance: ",BotDetector.safeDistance); //unused but keeping
+		ConfigurationSection bdbc = bd.getConfigurationSection("bounds"); //unused but keeping
 		//BotDetector Bounds Configuration
 		BotDetector.relaxationFactor = bdbc.getDouble("relaxation_factor");
 		AFKPGC.debug("Bounding Box Relaxation Factor: ", BotDetector.relaxationFactor);

--- a/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
+++ b/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
@@ -110,9 +110,9 @@ public class ConfigurationReader {
 		AFKPGC.debug("Acceptable TPS: ", BotDetector.acceptableTPS);
 		BotDetector.frequency = bd.getInt("kicking_frequency");
 		AFKPGC.debug("Detector Frequency: ", BotDetector.frequency);
-		BotDetector.enableBans = bd.getBoolean("enable_bans"); //TODO
+		BotDetector.enableBans = bd.getBoolean("enable_bans");
 		AFKPGC.debug("Activate Bans: ", BotDetector.enableBans);
-		BotDetector.enableWarnings = bd.getBoolean("enable_warnings"); //TODO
+		BotDetector.enableWarnings = bd.getBoolean("enable_warnings");
 		AFKPGC.debug("Activate Warnings: ", BotDetector.enableWarnings);
 		BotDetector.maxLocations = bd.getInt("max_locations");
 		AFKPGC.debug("Max Locs to Track: ", BotDetector.maxLocations);

--- a/src/com/github/Kraken3/AFKPGC/Suspect.java
+++ b/src/com/github/Kraken3/AFKPGC/Suspect.java
@@ -12,16 +12,16 @@ public class Suspect implements Comparable<Suspect> {
 	private UUID uuid;
 	private String name;
 	private Location location;
-	private BoundResults results;
+	private Long results;
 	
-	public Suspect(UUID uuid, String name, Location location, BoundResults results) {
+	public Suspect(UUID uuid, String name, Location location, Long results) {
 		this.uuid = uuid;
 		this.name = name;
 		this.location = location;
 		this.results = results;
 	}
 
-	public void update(Location location, BoundResults results) {
+	public void update(Location location, Long results) {
 		this.location = location;
 		this.results = results;
 	}
@@ -35,7 +35,7 @@ public class Suspect implements Comparable<Suspect> {
 	public Location getLocation() {
 		return this.location;
 	}
-	public BoundResults getResults() {
+	public Long getResults() {
 		return this.results;
 	}
 

--- a/src/com/github/Kraken3/AFKPGC/commands/GetLongBans.java
+++ b/src/com/github/Kraken3/AFKPGC/commands/GetLongBans.java
@@ -15,10 +15,10 @@ public class GetLongBans extends AbstractCommand {
 
 	@Override
 	public boolean onCommand(CommandSender sender, List<String> args) {
-		if (BotDetector.longBans)
-			sender.sendMessage("Long bans are currently enabled in the bot detector");
+		if (BotDetector.enableBans)
+			sender.sendMessage("Bans are currently enabled in the bot detector");
 		else
-			sender.sendMessage("Long bans are currently not enabled in the bot detector");
+			sender.sendMessage("Bans are currently not enabled in the bot detector");
 		return true;
 	}
 }

--- a/src/com/github/Kraken3/AFKPGC/commands/GetSuspectedPlayers.java
+++ b/src/com/github/Kraken3/AFKPGC/commands/GetSuspectedPlayers.java
@@ -6,6 +6,7 @@ import org.bukkit.command.CommandSender;
 
 import com.github.Kraken3.AFKPGC.AFKPGC;
 import com.github.Kraken3.AFKPGC.BotDetector;
+import com.github.Kraken3.AFKPGC.Suspect;
 
 public class GetSuspectedPlayers extends AbstractCommand {
 
@@ -15,14 +16,12 @@ public class GetSuspectedPlayers extends AbstractCommand {
 
 	@Override
 	public boolean onCommand(CommandSender sender, List<String> args) {
-		String s = "";
-		for (int i = 0; i < BotDetector.warnedPlayers.size(); i++) {
-			s = s + BotDetector.warnedPlayers.get(i) + ", ";
+		StringBuilder s = new StringBuilder();
+		for (Suspect wp : BotDetector.warnedPlayers) {
+			s.append(wp.getUUID()).append(", ");
 		}
-		if (s.length() != 0) {
-			s = s.substring(0, s.length() - 1); // remove last comma
-		}
-		sender.sendMessage("Currently suspected by the botdetector are: " + s);
+		sender.sendMessage("Currently suspected by the botdetector are: " +
+				(s.length() > 0 ? s.substring(0, s.length() - 2) : s.toString()));
 		return true;
 	}
 

--- a/src/com/github/Kraken3/AFKPGC/commands/SetLongBans.java
+++ b/src/com/github/Kraken3/AFKPGC/commands/SetLongBans.java
@@ -16,13 +16,13 @@ public class SetLongBans extends AbstractCommand {
 	public boolean onCommand(CommandSender sender, List<String> args) {
 		if (args.size() == 1) {
 			if (args.get(0).matches("true")) {
-				BotDetector.longBans = true;
-				sender.sendMessage("Set long bans to true");
+				BotDetector.enableBans = true;
+				sender.sendMessage("Enabled bans");
 				return true;
 			}
 			if (args.get(0).matches("false")) {
-				BotDetector.longBans = false;
-				sender.sendMessage("Set long bans to false");
+				BotDetector.enableBans = false;
+				sender.sendMessage("Disabled bans");
 				return true;
 			}
 		}


### PR DESCRIPTION
Changes/presquash commit log:

* Scan refactor, ignoring location and other factors and just scanning. A little complex because of per round scan limits. Initial commit with first changes, fleshing out framework. Feel free to comment

* Upping version, tweaks based on earlier review and other fixes, tossing up to test next

* Pulling out dead code now that we are moving away from location. Leaving the basis code for some of the location features in case we want to use it in the future. Updated bundle config and the configuration loader.

* Fixes for efficiency, NPE, and the like; adding ability to suppress cache when we are rechecking someone's lag sourcing just before warnings or kicks. carebear, warn only, and warn and kick modes all tested.

## General Notes and how to configure AFKPGC's new features

* Instead of location, uses a progressive scan of players over a series of invocations (when "tps" threshold is passed). Use the ```players_checked_per_run``` config line to control how many players, at most, are inspected each run. I recommend 5; more and AFKPGC could begin to consume too many server resources.

* As it accrues suspects and clears innocents, it nears a threshold, computed as a percentage of online players; once this threshold is crossed, warnings are issued. Use the ```action_threshold``` value to control. Set to ```0``` if you always want to immediately issue warnings to top suspects as they are found; set above ```1``` if you basically never want to issue warnings or kicks but like log spam. I personally recommend setting it to ```0.8```, which roughly means once 80% of online players have been scanned, start issuing warnings to the worst discoveries. 

* To prevent issuing a ton of warnings all at once, AFKPGC can also be progressing in its issuing of warnings and kicks. Use ```max_kicked_per_run``` to control how many warnings or kicks to issue.

* Before issuing a warning or a kick, AFKPGC will perform a new scan of the surroundings around the player. This scan never uses the cache. Slightly increases server hit to ensure that we only ever issue warnings and kickbans to players whose active location is a problem. Use ```enable_warnings``` to turn on or off the delivery of warning messages to players.

* Once a warning has been issued, the player's UUID is added to a list. The next round, if they are still a top offender (we haven't found someone worse), their current location is rescanned. If still sitting overtop a lag source, they are immediately kickbanned. Use ```enable_bans``` to turn on or off the delivery of bans. Use ```ban_length``` to control, in milliseconds, how long to ban offenders.

* This process of progressive scanning and kicking will continue until there are no offenders found and everyone has been granted a reprieve, or until TPS returns to safe levels. Reprieves are granted on a passing scan, and decrement on every execution of AFKPGC. All reprieves, suspect lists, and bans are cleared and released when TPS has been "safe" for a long time. Use ```release_rounds``` to configure how many consecutive scan rounds at good TPS must be observed before releasing bans. Use ```max_reprieve``` to configure how many scan rounds to ignore a player if they are scanned and cleared.

* Use ```acceptable_TPS``` to control the threshold at which scanning begins. Set this to a safe but aggressive value for maximum benefit; I recommend ```17.5```, as when TPS goes below this number future impacts on tick are more significant (performance degradation is *not* linear).

* Use ```observation_mode``` to disable all kicking and banning together. Players are still scanned, reprieved, or flagged, but they are never kicked nor banned. Very useful while tuning the "relative lag scores" used to compute a player's impact.

* Use ```kicking_frequency``` to control, in server ticks, how often to schedule BotDetector. Note that BotDetector will use this as its "target" tick count inbetween invocations, but will adapt its next invocation relative to current server TPS. This is to ensure that BotDetector has an opportunity to run when TPS drops very low.

* Use ```scan_radius``` to control how many radial slices of chunks around a player to scan for lag sources during a LagScanner execution. If 4, scans 81 chunks around the player; if 3, scans 49; if 2, scans 25, etc. This in conjunction with the LagScanner config will inform how to construct and weigh the lag sources identified.

## Configuring the LagScanner

All these configuration options live under ```lag_scanner``` within the config.

* Use ```cache_timeout``` to control, in milliseconds, how long a previous scan of a chunk should be stored. Use your best judgment; 30 minutes is a safe value, although more "paranoid" administrators could use a lower value.

* Use ```full_scan``` to force the full radius around a player to be scanned, regardless if thresholds are met. I recommend full_scan be used while tuning, but turned off once the configuration is satisfactory and only turned back on if problems are reported. It will generally result in a significant reduction in chunk scans if off, leading to a leaner, more efficient LagScanner with no loss of functionality.

* Use ```lag_threshold``` to control the summation of chunk "lag" scores at which point a player is considered a significant lag source. Tune this relative to the "weights" you've assigned entities and blocks, based on your target model for lag source estimation.

* Although still present ```extreme_lag_threshold_multiplier``` is not used to determine lag source. However, it is tracked by LagScanner and may be used in the future. It is a direct multiple of ```lag_threshold``` used to determine if a player is not only a lag source, but a particularly bad lag source, based on the target model for lag source estimation.

* Use ```perform_unload``` and ```unload_threshold_factor``` to control which chunks LagScanner makes a best-effort attempt to unload after a player kick. Set ```perform_unload``` to true for any chunk unloading requests to be generated, and choose a value between 0 and 1 for ```unload_threshold_factor```, which is multiplied against ```lag_threshold```; any chunk found during the scan around a player that exceeds this unload threshold will generate an unload request if that player is kicked.

* ```normal_chunk_value``` is a minimum threshold that a chunk must exceed to be considered in the lag estimation at all. Set to 0 if you want all chunks to contribute. I recommend tuning it such that a small number of mobs and tick entities can be present in a chunk before they contribute to the lag score summation. This is to help handle urban areas that often have a large number of "low value" lag sources, but when scanning 81 chunks around a player sum to a very large, but incorrect, estimated lag contribution score.

* There are two lists as a subsection under configuration items ```tick_block``` and ```tick_entity```. For blocks, use the Bukkit Material enumeration name as the key, and the "weight" as an integer value. For entities, use the Bukkit EntityType enumeration name as the key, and the "weight" as an integer value.

A few tips on setting the lag weights:

* Chests, signs, banners are unlikely to contribute to lag. Either don't put them on the list, set them to a relatively small value, or to 0.

* Anything not specified in the list is assumed to be value "0" in the lag summation. Thus, feel free to have a minimal config that only includes the elements you intend to weigh.

* Moving pistons (pistons that are "active") and falling blocks are both consistent lag contributors if left running. I recommend those values be "relatively" high within your config. 

* Hoppers actively collecting item drops can be a major source of lag in sufficient numbers, but are a minimal source of lag if not actively collective drops. Sadly, we do not currently support "combined presence" keys and values; hence, I recommend low value for dropped items, and a modest value for hoppers.

* Furnaces in great numbers can lead to some instances of lag, although exactly why is not yet certain. Consider a low value, such that only if truly immense numbers of furnaces are present the threshold will be met.

All other options and configuration values are unchanged (AFK kicker works as it has, immunity is respected). 

## Good luck!