### PR TITLE
Removed from warned list if a player we are tracking logs out after the warning.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,26 +25,39 @@ bot_detector:
   enable_warnings: true
   # Completely disables banning for testing and debugging purposes
   observation_mode: false
-  # Length of long ban
+  # Length of "default" long ban
   ban_length: 5400000
   # Max locations per player to store while measuring movement patterns
   max_locations: 10
   # Max suspects to consider per Detector round
   max_suspects: 10
   # Maximum scan rounds to "ignore" a player who was previously cleared as a lag source
-  max_reprieve: 20
+  max_reprieve: 10
   # Number of BotDetector rounds at good TPS before releasing lag offenders
-  release_rounds: 40
+  release_rounds: 30
   # Scan radius in chunks around location, to check for lag causes
   scan_radius: 3
   # Amount of players checked per run
-  players_checked_per_run: 5
+  players_checked_per_run: 8
   # Max players kicked per run
   max_kicked_per_run: 4
   # percentage of online players that need to have been scanned before kicking/warning begins
   action_threshold: 0.8
   # Distance a player needs to move away from a lagsource to not get kicked if he is caught by the system again
   safe_distance: 128
+  # The message to send to the player being banned.
+  ban_message: §4You have been banned due to causing lag, in spite of a warning to leave the area.
+  # The warning message to send to a player found near lag sources.
+  warning_message: §4[WARNING] You are in a region with a high concentration of lag sources. Please immediately depart the area (leave render distance) or you will be temporarily banned.
+  # The number of times to send a warning to a player who repeatedly logs off after a warning, before banning.
+  warning_repeat: 3
+  # The lenths of bans. As a player is banned more times, the ban length goes up. All is clear on server reset.
+  ban_lengths:
+    - 150000
+    - 300000
+    - 900000
+    - 1800000
+    - 3600000
   # Configure the threshold and individual contribution of bound types
   bounds:
     relaxation_factor: 0.1
@@ -60,11 +73,13 @@ lag_scanner:
   # Length of time to cache individual chunk results (in milliseconds)
   cache_timeout: 1800000
   # Summation threshold of entity and tile costs for lag flag
-  lag_threshold: 750
+  lag_threshold: 700
   # Multiplier of the lag threshold that needs to be exceeded to be banned right away
   extreme_lag_threshold_multiplier: 4.5
   # Reduction Factor (threshold * unload should be < threshold) that must be exceeded to attempt to force unload chunks
-  unload_threshold_factor: 0.14
+  unload_threshold_factor: 0.10
+  # Innocents Threshold. If not prior banned, offer a more "relaxed" threshold. Applied as a multiplier to Threshold.
+  innocent_boundary: 1.15
   # Flag indicating if chunk force unloading on kick should be active
   perform_unload: true
   # Whether the lag scanner should keep scanning if it already determined someone is causing lag
@@ -72,7 +87,7 @@ lag_scanner:
   full_scan: true
   # If a chunk's lag count is below this value, it is considered "normal" and not taken into account for the
   # total lag count calculation
-  normal_chunk_value: 100
+  normal_chunk_value: 120
   # Per tickable block cost 
   tick_block:
     PISTON_MOVING_PIECE: 16
@@ -81,14 +96,14 @@ lag_scanner:
     BEACON: 3
     BREWING_STAND: 1
     MOB_SPAWNER: 5
-    DROPPER: 5
+    DROPPER: 4
     JUKEBOX: 1
     NOTE_BLOCK: 1
     SIGN: 0
     HOPPER: 8
-    DISPENSER: 5
-    FURNACE: 2
-    BURNING_FURNACE: 4
+    DISPENSER: 4
+    FURNACE: 1
+    BURNING_FURNACE: 3
     CHEST: 0
     TRAPPED_CHEST: 0
     ENDER_CHEST: 0
@@ -169,7 +184,6 @@ warnings:
   - 600 §4AFK Plugin - You'll be kicked in 10 minutes
   - 1800 §4AFK Plugin - You'll be kicked in 30 minutes
   - 3600 §4AFK Plugin - You'll be kicked in 1 hour
-  
   
 # Yay, rainbows! :)  
 kick_message: §cYou §6were §ekicked §adue §9to in§5activity

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.github.Kraken3</groupId>
   <artifactId>AFKPGC</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.3-${build.version}</version>
+  <version>1.3.4-${build.version}</version>
   <name>AFKPGC</name>
   <url>https://github.com/civcraft/AFKPGC</url>
   

--- a/src/com/github/Kraken3/AFKPGC/BotDetector.java
+++ b/src/com/github/Kraken3/AFKPGC/BotDetector.java
@@ -274,6 +274,10 @@ public class BotDetector implements Runnable {
 						} else {
 							AFKPGC.debug("Player ", suspectUUID, " (", suspect.getName(), 
 									") is likely offline, skipping recheck for now");
+							// remove from warned list, if there.
+							if (warnedPlayers.contains(suspect)) {
+								warnedPlayers.remove(suspect);
+							}
 						} // TODO remove after N skips?
 
 						if (curKicks >= maxKicksPerRun) {

--- a/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
+++ b/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
@@ -132,6 +132,19 @@ public class ConfigurationReader {
 		AFKPGC.debug("Action Threshold:", BotDetector.actionThreshold);
 		BotDetector.safeDistance = bd.getInt("safe_distance");
 		AFKPGC.debug("Safe distance: ",BotDetector.safeDistance); //unused but keeping
+		BotDetector.warningMessage = conf.getString("warning_message");
+		AFKPGC.debug("Warning message: ",BotDetector.warningMessage);
+		BotDetector.warningCount = conf.getInt("warning_repeat");
+		AFKPGC.debug("Warning repeat: ",BotDetector.warningCount);
+		BotDetector.banMessage = conf.getString("ban_message");
+		AFKPGC.debug("Ban message: ",BotDetector.banMessage);
+		List<Long> banLengths = conf.getLongList("ban_lengths");
+		BotDetector.banLengths = banLengths;
+		AFKPGC.debug("Ban Lengths: ");
+		for (Long i : banLengths) {
+			AFKPGC.debug("  ", i);
+		}
+		
 		ConfigurationSection bdbc = bd.getConfigurationSection("bounds"); //unused but keeping
 		//BotDetector Bounds Configuration
 		BotDetector.relaxationFactor = bdbc.getDouble("relaxation_factor");
@@ -174,6 +187,8 @@ public class ConfigurationReader {
 		LagScanner.unloadThreshold = (long) (LagScanner.lagSourceThreshold 
 				* ls.getDouble("unload_threshold_factor"));
 		AFKPGC.debug("LagScanner Chunk Unload Threshold: ",LagScanner.unloadThreshold);
+		LagScanner.innocentThreshold = (long) (LagScanner.lagSourceThreshold * ls.getDouble("innocent_boundary"));
+		AFKPGC.debug("LagScanner Innocent Threshold: ",LagScanner.innocentThreshold);
 		LagScanner.performUnload = ls.getBoolean("perform_unload");
 		AFKPGC.debug("LagScanner Perform Chunk Unload: ", LagScanner.performUnload);
 		LagScanner.normalChunkValue = ls.getInt("normal_chunk_value");

--- a/src/com/github/Kraken3/AFKPGC/LagScanner.java
+++ b/src/com/github/Kraken3/AFKPGC/LagScanner.java
@@ -26,6 +26,7 @@ public class LagScanner {
 	public static long lagSourceThreshold;
 	public static long extremeLagSourceThreshold;
 	public static long unloadThreshold;
+	public static long innocentThreshold;
 	public static boolean performUnload;
 	public static boolean fullScan;
 	public static long normalChunkValue;


### PR DESCRIPTION
Friendly change, that way they get warned on login instead of instaban.

Previously, if someone logged out due to a warning, then logged back in within their lag machine, next detection cycle they'd get the boot right away. This will give another warning instead.