### PR TITLE
Add option to always warn players

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -29,6 +29,8 @@ bot_detector:
   enable_warnings: true
   # Completely disables banning for testing and debugging purposes
   observation_mode: false
+  #Whether warnings to players should be given out, even if the tps is good
+  always_warn: true
   # Length of "default" long ban
   ban_length: 5400000
   # Max locations per player to store while measuring movement patterns
@@ -51,8 +53,10 @@ bot_detector:
   safe_distance: 128
   # The message to send to the player being banned.
   ban_message: §4You have been banned due to causing lag, in spite of a warning to leave the area.
-  # The warning message to send to a player found near lag sources.
+  # The warning message to send to a player found near lag sources, while the tick is low
   warning_message: §4[WARNING] You are in a region with a high concentration of lag sources. Please immediately depart the area (leave render distance) or you will be temporarily banned.
+  # The warning message to sent to a player found near a lag source, while the tick is high, if always_warn is enabled
+  friendly_warning_message: §4[WARNING] You are in a region with a high concentration of lag sources. We would recommend to remove entities around you, you might get kicked when the tick drops.
   # The number of times to send a warning to a player who repeatedly logs off after a warning, before banning.
   warning_repeat: 3
   # The lenths of bans. As a player is banned more times, the ban length goes up. All is clear on server reset.

--- a/config.yml
+++ b/config.yml
@@ -29,8 +29,10 @@ bot_detector:
   enable_warnings: true
   # Completely disables banning for testing and debugging purposes
   observation_mode: false
-  #Whether warnings to players should be given out, even if the tps is good
+  # Whether warnings to players should be given out, even if the tps is good
   always_warn: true
+  # How often players should be warned if always_warn is enabled. Value of X here means players are warned every X runs of the BotDetector
+  reminder_interval: 10
   # Length of "default" long ban
   ban_length: 5400000
   # Max locations per player to store while measuring movement patterns

--- a/src/com/github/Kraken3/AFKPGC/BotDetector.java
+++ b/src/com/github/Kraken3/AFKPGC/BotDetector.java
@@ -47,6 +47,8 @@ public class BotDetector implements Runnable {
 	public static int amountOfChecksPerRun;
 	public static int maxKicksPerRun;//TODO
 	public static int safeDistance;
+	/** How often players should be warned, if alwaysWarn is enabled and the tick is good */
+	public static int reminderInterval;
 	/** Number of people scanned between suspects and reprieve list before kicks begin, as a function
 	  * of online players. */
 	public static float actionThreshold;
@@ -73,6 +75,8 @@ public class BotDetector implements Runnable {
 	HashMap<UUID, Integer> reprieve; // temp. cleared suspects
 
 	int goodRounds = 0;
+	
+	int reminderCounter=0;
 	
 	/**
 	 * Suspect is key, count of warnings before either ban or clear is value
@@ -120,6 +124,9 @@ public class BotDetector implements Runnable {
 	}
 
 	public synchronized void doDetector() {
+		if (currentTPS >= acceptableTPS && alwaysWarn) {
+			reminderCounter++;
+		}
 		if (topSuspects == null) {
 			topSuspects = new TreeMap<Long, Set<Suspect>>();
 		}
@@ -155,7 +162,10 @@ public class BotDetector implements Runnable {
 		currentTPS = TpsReader.getTPS();
 		AFKPGC.debug("Bot Detector Running, TPS is: ", currentTPS);
 		Map<UUID, LastActivity> lastActivities = LastActivity.lastActivities;
-		if (alwaysWarn || currentTPS < acceptableTPS) {
+		if (currentTPS < acceptableTPS || (alwaysWarn && reminderCounter == reminderInterval )) {
+			if (reminderCounter == reminderInterval) {
+				reminderCounter = 0;
+			}
 			goodRounds = 0;
 			int scanCount = 0;
 			HashSet<UUID> justScanned = new HashSet<UUID>();

--- a/src/com/github/Kraken3/AFKPGC/BotDetector.java
+++ b/src/com/github/Kraken3/AFKPGC/BotDetector.java
@@ -56,8 +56,14 @@ public class BotDetector implements Runnable {
 
 	/** Boolean indicator if warnings are active. Bans can be active without warnings, for instance. */
 	public static boolean enableWarnings;
-
+	/**Allows to give out warnings to players in laggy areas, even if the tps is high	 */
+	public static boolean alwaysWarn;
+	
+	/** Message sent to a player if he is in a laggy area, while the tick is low*/
 	public static String warningMessage;
+	
+	/** Message sent to a player if he is in a laggy area, but the tick is good, just to remind him*/
+	public static String friendlyWarningMessage;
 	public static String banMessage;
 	public static List<Long> banLengths;
 	public static int warningCount;
@@ -149,7 +155,7 @@ public class BotDetector implements Runnable {
 		currentTPS = TpsReader.getTPS();
 		AFKPGC.debug("Bot Detector Running, TPS is: ", currentTPS);
 		Map<UUID, LastActivity> lastActivities = LastActivity.lastActivities;
-		if (currentTPS < acceptableTPS) {
+		if (alwaysWarn || currentTPS < acceptableTPS) {
 			goodRounds = 0;
 			int scanCount = 0;
 			HashSet<UUID> justScanned = new HashSet<UUID>();
@@ -259,8 +265,9 @@ public class BotDetector implements Runnable {
 									removeCellmates.put(suspect, oldScore);
 									updates.add(suspect);
 								}
-								if (warnedPlayers.contains(suspect)) {
-									// kick, add to ban list.
+								if (warnedPlayers.contains(suspect) && currentTPS < acceptableTPS) {
+									// kick, add to ban list, additional tps check needed here, in case always warning is enabled and
+									// the tps is good right now
 									if (enableBans && !observationMode) {
 										giveOutBan(suspect);
 										// Once banned, remove from top list, update, and such.
@@ -452,7 +459,11 @@ public class BotDetector implements Runnable {
 	
 	public void warnPlayer(Player p) {
 		if (p != null) {
-			p.sendMessage(warningMessage);
+			if (currentTPS < acceptableTPS) {
+				p.sendMessage(warningMessage); }
+			else {
+				p.sendMessage(friendlyWarningMessage);
+			}
 			AFKPGC.debug("Player ", p.getUniqueId(), " (", p.getName(), ") was notified of presence in lag source");
 		}
 		

--- a/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
+++ b/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
@@ -136,6 +136,8 @@ public class ConfigurationReader {
 		AFKPGC.debug("Warning message: ",BotDetector.warningMessage);
 		BotDetector.friendlyWarningMessage = bd.getString("friendly_warning_message");
 		AFKPGC.debug("Friendly warning message: ",BotDetector.friendlyWarningMessage);
+		BotDetector.reminderInterval = bd.getInt("reminder_interval");
+		AFKPGC.debug("Reminder interval: ",BotDetector.reminderInterval);
 		BotDetector.warningCount = bd.getInt("warning_repeat");
 		AFKPGC.debug("Warning repeat: ",BotDetector.warningCount);
 		BotDetector.banMessage = bd.getString("ban_message");

--- a/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
+++ b/src/com/github/Kraken3/AFKPGC/ConfigurationReader.java
@@ -134,10 +134,14 @@ public class ConfigurationReader {
 		AFKPGC.debug("Safe distance: ",BotDetector.safeDistance); //unused but keeping
 		BotDetector.warningMessage = bd.getString("warning_message");
 		AFKPGC.debug("Warning message: ",BotDetector.warningMessage);
+		BotDetector.friendlyWarningMessage = bd.getString("friendly_warning_message");
+		AFKPGC.debug("Friendly warning message: ",BotDetector.friendlyWarningMessage);
 		BotDetector.warningCount = bd.getInt("warning_repeat");
 		AFKPGC.debug("Warning repeat: ",BotDetector.warningCount);
 		BotDetector.banMessage = bd.getString("ban_message");
 		AFKPGC.debug("Ban message: ",BotDetector.banMessage);
+		BotDetector.alwaysWarn = bd.getBoolean("always_warn");
+		AFKPGC.debug("AlwaysWarn: ",BotDetector.alwaysWarn);
 		List<Long> banLengths = bd.getLongList("ban_lengths");
 		BotDetector.banLengths = banLengths;
 		AFKPGC.debug("Ban Lengths: ");


### PR DESCRIPTION
Adressing https://github.com/Civcraft/AFK-Player-GC/issues/23

If the tps is good, it counts and just runs the actual BotDetector every X normal runs. 

@ProgrammerDan 