### PR TITLE
Lag investigation tooling

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -92,6 +92,11 @@ commands:
       usage: /afkpgc freeeveryone
       aliases: fe
       permission: AFKPGC.execute
+   afkpgc investigate:
+      description: Investigates the next uninvestigated lag source
+      usage: /afkpgc investigate
+      aliases: inv
+      permission: AFKPGC.execute
 permissions:
     AFKPGC.*:
       description: Gives access to all afkpgc commands
@@ -115,5 +120,5 @@ permissions:
       description: Allows you to use /afkpgc setacceptabletps, /afkpgc setcriticaltpschange, /afkpgc setlongbans, /afkpgc stop, /afkpgc reload, and /afkpgc toggledebug
       default: op
     AFKPGC.execute:
-      description: Allows you to use /afkpgc forcebotdetector, /afkpgc clearallreprieve, /afkpgc listallreprieve, /afkpgc freeeveryone
+      description: Allows you to use /afkpgc forcebotdetector, /afkpgc clearallreprieve, /afkpgc listallreprieve, /afkpgc freeeveryone, /afkpgc investigate
       default: op

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.github.Kraken3</groupId>
   <artifactId>AFKPGC</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.4-${build.version}</version>
+  <version>1.3.5-${build.version}</version>
   <name>AFKPGC</name>
   <url>https://github.com/civcraft/AFKPGC</url>
   

--- a/src/com/github/Kraken3/AFKPGC/LagScanner.java
+++ b/src/com/github/Kraken3/AFKPGC/LagScanner.java
@@ -74,8 +74,7 @@ public class LagScanner {
 				if (worldChecked.contains(chunk)) {
 					return; // already marked, so fail fast.
 				}
-			}
-			if (worldChecked == null) {
+			} else {
 				worldChecked = new TreeSet<Long>();
 				worstChunksChecked.put(world, worldChecked);
 			}

--- a/src/com/github/Kraken3/AFKPGC/LagScanner.java
+++ b/src/com/github/Kraken3/AFKPGC/LagScanner.java
@@ -3,12 +3,17 @@ package com.github.Kraken3.AFKPGC;
 import org.bukkit.Location;
 import org.bukkit.Chunk;
 import org.bukkit.World;
+import org.bukkit.Bukkit;
 import org.bukkit.block.BlockState;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.HashSet;
+import org.apache.commons.lang.mutable.MutableLong;
 
 /**
  * Should be runnable with callback. First iteration will be straight mainthread code, b/c testing.
@@ -21,6 +26,121 @@ public class LagScanner {
 
 	private static Map<String, Map<Long, LagScanner.Result>> cache = 
 			new HashMap<String, Map<Long, LagScanner.Result>>();
+
+	private static Map<String, TreeMap<Long, HashSet<Long>>> worstChunksUnchecked = 
+			new HashMap<String, TreeMap<Long, HashSet<Long>>>();
+	private static Map<String, TreeMap<Long, Long>> worstChunksUncheckedIdx = 
+			new HashMap<String, TreeMap<Long, Long>>();
+	private static Map<String, TreeSet<Long>> worstChunksChecked = 
+			new HashMap<String, TreeSet<Long>>();
+
+	/**
+	 * Gets another chunk. Goes world by world from worst chunk to best in the world.
+	 */
+	public static Location getNextBadChunk(MutableLong ml, boolean mark) {
+		synchronized(worstChunksChecked) {
+			for (String world : worstChunksUnchecked.keySet()) {
+				TreeMap<Long, HashSet<Long>> worldBad = worstChunksUnchecked.get(world);
+				if (worldBad != null && !worldBad.isEmpty()) {
+					for (Long score : worldBad.descendingKeySet()) {
+						HashSet<Long> locations = worldBad.get(score);
+						if (locations != null && !locations.isEmpty()) {
+							Long location = locations.iterator().next();
+							long chunkX = location >> 32L;
+							long chunkZ = location - (chunkX << 32L);
+							World worldQ = Bukkit.getWorld(world);
+							int locX = ((int)chunkX) * 16 + 8;
+							int locZ = ((int)chunkZ) * 16 + 8;
+							int locY = worldQ.getHighestBlockYAt(locX, locZ) + 2;
+							if (ml != null) {ml.setValue(score);}
+							if (mark) { LagScanner.markBadChunk(world, location); }
+							return new Location(worldQ, (double)locX, (double)locY, (double)locZ);
+							// find and return first location found.
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Marks a bad chunk as reviewed
+	 */
+	public static void markBadChunk(String world, Long chunk) {
+		synchronized(worstChunksChecked) {
+			TreeSet<Long> worldChecked = worstChunksChecked.get(world);
+			if (worldChecked != null) {
+				if (worldChecked.contains(chunk)) {
+					return; // already marked, so fail fast.
+				}
+			}
+			if (worldChecked == null) {
+				worldChecked = new TreeSet<Long>();
+				worstChunksChecked.put(world, worldChecked);
+			}
+			worldChecked.add(chunk);
+			// now remove from unchecked list.
+			TreeMap<Long, Long> worldIndex = worstChunksUncheckedIdx.get(world);
+			TreeMap<Long, HashSet<Long>> worldChunks = worstChunksUnchecked.get(world);
+			if (worldIndex != null) {
+				Long curval = worldIndex.get(chunk);
+				if (curval != null) { // exists.
+					HashSet<Long> valChunks = worldChunks.get(curval);
+					if (valChunks != null) {
+						valChunks.remove(chunk);
+						worldIndex.remove(chunk);
+					} else {
+						// TODO: soft exception
+					}
+				} // else doesn't exist, don't remove.
+			} // else doesn't exist, don't remove.
+		}
+	}
+
+
+	/**
+	 * Adds or updates a "bad chunk" for admin review
+	 */
+	public static void addBadChunk(String world, Long chunk, Long weight) {
+		synchronized(worstChunksChecked) {
+			TreeSet<Long> worldChecked = worstChunksChecked.get(world);
+			if (worldChecked != null) {
+				if (worldChecked.contains(chunk)) {
+					return; // checked already so fail fast.
+				}
+			} else {
+				worldChecked = new TreeSet<Long>();
+				worstChunksChecked.put(world, worldChecked);
+			}
+			TreeMap<Long, HashSet<Long>> worldC = worstChunksUnchecked.get(world);
+			TreeMap<Long, Long> worldI = worstChunksUncheckedIdx.get(world);
+			if (worldC == null) {
+				worldC = new TreeMap<Long, HashSet<Long>>(); // create new world weight index
+				worstChunksUnchecked.put(world, worldC);
+			}
+			if (worldI == null) {
+				worldI = new TreeMap<Long, Long>(); // create new world chunk index
+				worstChunksUncheckedIdx.put(world, worldI); 
+			}
+			Long prevWeight = worldI.get(chunk);
+			if (prevWeight != null) {
+				if (prevWeight.equals(weight)) {
+					return; // no change;
+				}
+				HashSet<Long> chunks = worldC.get(prevWeight);
+				chunks.remove(chunk); // remove old from weight index
+			}
+			HashSet<Long> chunks = worldC.get(weight);
+			if (chunks == null) {
+				chunks = new HashSet<Long>();
+				worldC.put(weight, chunks); // create weight index
+			}
+			chunks.add(chunk); // add to weight index
+			worldI.put(chunk, weight); // add to chunk index
+		}
+	}
+
 
 	public static long cacheTimeout;
 	public static long lagSourceThreshold;
@@ -207,6 +327,8 @@ public class LagScanner {
 		if (result.lagContrib < normalChunkValue) {
 			return new LagScanner.Result(null, 0, 0, 0, 0L, 0L);
 		}
+		// add to admincrimes list
+		LagScanner.addBadChunk(world, chunkId, result.lagContrib);
 		return result;
 	}
 

--- a/src/com/github/Kraken3/AFKPGC/commands/CommandHandler.java
+++ b/src/com/github/Kraken3/AFKPGC/commands/CommandHandler.java
@@ -28,7 +28,8 @@ public class CommandHandler implements CommandExecutor {
 				new ListPlayers(plugin), new Reload(plugin), new Stop(plugin),
 				new Times(plugin), new ForceBotDetector(plugin),
 				new ClearAllReprieve(plugin), new ListAllReprieve(plugin),
-				new ToggleDebug(plugin), new FreeEveryone(plugin) });
+				new ToggleDebug(plugin), new FreeEveryone(plugin),
+				new LagInvestigation(plugin) });
 	}
 
 	private void registerCommands(AbstractCommand[] abstractCommands) {

--- a/src/com/github/Kraken3/AFKPGC/commands/LagInvestigation.java
+++ b/src/com/github/Kraken3/AFKPGC/commands/LagInvestigation.java
@@ -3,12 +3,16 @@ package com.github.Kraken3.AFKPGC.commands;
 import org.bukkit.command.CommandSender;
 
 import java.util.List;
+import java.util.UUID;
 
 import com.github.Kraken3.AFKPGC.AFKPGC;
 import com.github.Kraken3.AFKPGC.LagScanner;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Entity;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import org.apache.commons.lang.mutable.MutableLong;
 
@@ -23,13 +27,23 @@ public class LagInvestigation extends AbstractCommand {
 		if (sender instanceof Player) {
 			Player p = (Player) sender;
 			MutableLong chunkWeight = new MutableLong(0L);
-			Location nextUp = LagScanner.getNextBadChunk(chunkWeight, true);
+			final Location nextUp = LagScanner.getNextBadChunk(chunkWeight, true);
 			if (nextUp != null) {
 				sender.sendMessage("Teleporting you to an uninvestigated Lag area (weight " + chunkWeight.longValue() + "): " + nextUp.toString());
 				if (p.isInsideVehicle()) {
-					p.leaveVehicle();
+					if (!p.leaveVehicle()) {
+						Entity veh = p.getVehicle();
+						veh.eject();
+					}
 				}
-				p.teleport(nextUp);
+				final UUID playerUUID = p.getUniqueId();
+				new BukkitRunnable() {
+						@Override
+						public void run() {
+							Player q = Bukkit.getPlayer(playerUUID);
+							q.teleport(nextUp);
+						}
+				}.runTaskLater(super.plugin, 2);
 			} else {
 				sender.sendMessage("Nothing left to investigate");
 			}

--- a/src/com/github/Kraken3/AFKPGC/commands/LagInvestigation.java
+++ b/src/com/github/Kraken3/AFKPGC/commands/LagInvestigation.java
@@ -26,6 +26,9 @@ public class LagInvestigation extends AbstractCommand {
 			Location nextUp = LagScanner.getNextBadChunk(chunkWeight, true);
 			if (nextUp != null) {
 				sender.sendMessage("Teleporting you to an uninvestigated Lag area (weight " + chunkWeight.longValue() + "): " + nextUp.toString());
+				if (p.isInsideVehicle()) {
+					p.leaveVehicle();
+				}
 				p.teleport(nextUp);
 			} else {
 				sender.sendMessage("Nothing left to investigate");

--- a/src/com/github/Kraken3/AFKPGC/commands/LagInvestigation.java
+++ b/src/com/github/Kraken3/AFKPGC/commands/LagInvestigation.java
@@ -8,6 +8,7 @@ import com.github.Kraken3.AFKPGC.AFKPGC;
 import com.github.Kraken3.AFKPGC.LagScanner;
 
 import org.bukkit.Location;
+import org.bukkit.entity.Player;
 
 import org.apache.commons.lang.mutable.MutableLong;
 
@@ -19,9 +20,19 @@ public class LagInvestigation extends AbstractCommand {
 
 	@Override
 	public boolean onCommand(CommandSender sender, List<String> args) {
-		MutableLong chunkWeight = new MutableLong(0L);
-		Location nextUp = LagScanner.getNextBadChunk(chunkWeight, true);
-		sender.sendMessage("Teleporting you to an uninvestigated Lag area (weight " + chunkWeight.longValue() + "): " + nextUp.toString());
+		if (sender instanceof Player) {
+			Player p = (Player) sender;
+			MutableLong chunkWeight = new MutableLong(0L);
+			Location nextUp = LagScanner.getNextBadChunk(chunkWeight, true);
+			if (nextUp != null) {
+				sender.sendMessage("Teleporting you to an uninvestigated Lag area (weight " + chunkWeight.longValue() + "): " + nextUp.toString());
+				p.teleport(nextUp);
+			} else {
+				sender.sendMessage("Nothing left to investigate");
+			}
+		} else {
+			sender.sendMessage("Can only invoke if a player in game");
+		}
 		return true;
 	}
 

--- a/src/com/github/Kraken3/AFKPGC/commands/LagInvestigation.java
+++ b/src/com/github/Kraken3/AFKPGC/commands/LagInvestigation.java
@@ -1,0 +1,29 @@
+package com.github.Kraken3.AFKPGC.commands;
+
+import org.bukkit.command.CommandSender;
+
+import java.util.List;
+
+import com.github.Kraken3.AFKPGC.AFKPGC;
+import com.github.Kraken3.AFKPGC.LagScanner;
+
+import org.bukkit.Location;
+
+import org.apache.commons.lang.mutable.MutableLong;
+
+public class LagInvestigation extends AbstractCommand {
+
+	public LagInvestigation(AFKPGC instance) {
+		super(instance, "investigate");
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, List<String> args) {
+		MutableLong chunkWeight = new MutableLong(0L);
+		Location nextUp = LagScanner.getNextBadChunk(chunkWeight, true);
+		sender.sendMessage("Teleporting you to an uninvestigated Lag area (weight " + chunkWeight.longValue() + "): " + nextUp.toString());
+		return true;
+	}
+
+}
+


### PR DESCRIPTION
Admin (operator only) tool for investigating lag. Be sure to add your account to the immune account list in the config before using it. 

Chunks investigated are marked, so future invocations of ```/afkpgc inv``` won't take you to the same place. Multiple investigators can work side by side, additional invocations of /afkpgc inv will always take you to the next worst location.

Chunks stored are cleared every server restart.

Might need to add an ability to clear or turn off this feature. When you put it online, keep an eye on the server that day.

Should make investigating lag sources far easier, it'll take you to anything that crosses the "acceptable" boundary at a per-chunk level, so even "low burn" bad sources will show up.